### PR TITLE
fix: column names needing quote marks for MySQL

### DIFF
--- a/src/TableHashers/MySqlTableHasher.php
+++ b/src/TableHashers/MySqlTableHasher.php
@@ -44,11 +44,14 @@ class MySqlTableHasher implements TableHasherInterface
         $fields = [];
         $tableDescription = $this->tableDescriber->describe($configName);
 
+        $dbConnection = DB::connection($config['connection']);
+        $dbGrammar = $dbConnection->getQueryGrammar();
+
         foreach ($tableDescription['columns'] as $column) {
-            $fields[] = 'IFNULL(' . $column['name'] . ', "' . ServiceProvider::NULL_VALUE . '")';
+            $columnName = $dbGrammar->wrap($column['name']);
+            $fields[] = 'IFNULL(' . $columnName . ', "' . ServiceProvider::NULL_VALUE . '")';
         }
 
-        $dbConnection = DB::connection($config['connection']);
         $dbConnection->statement('SET @crc := ""');
 
         $dbConnection->statement(


### PR DESCRIPTION
MySQL 8 introduced a `rank` function which clashes with columns also called rank.

https://dev.mysql.com/doc/refman/8.0/en/window-function-descriptions.html#function_rank

This fix adds quotes to the column names to avoid clashes.